### PR TITLE
fix: increase card size on desktop for better visual balance

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -121,7 +121,7 @@ function AppContent() {
     ? Math.floor(SCREEN_WIDTH * 0.9)
     : SCREEN_WIDTH < 1024
       ? Math.min(480, Math.floor(SCREEN_WIDTH * 0.7))
-      : 480;
+      : Math.min(600, Math.floor((SCREEN_WIDTH - 280) * 0.55));
   const cardHeight = Math.floor(cardWidth * (640 / 480));
 
   const { token, authError, setAuthError, copilotAvailable, startLogin, signOut } = useAuth();


### PR DESCRIPTION
Desktop card was capped at 480px, leaving too much empty space. Now scales with screen width (minus sidebar), capped at 600px. Mobile untouched.