### PR TITLE
fix: pass user's GitHub token to CopilotClient

### DIFF
--- a/api/src/app.js
+++ b/api/src/app.js
@@ -192,7 +192,7 @@ app.http('aiSummary', {
 
     try {
       const { CopilotClient, approveAll } = await import('@github/copilot-sdk');
-      client = new CopilotClient();
+      client = new CopilotClient({ githubToken: session.githubToken });
       await client.start();
       copilotSession = await client.createSession({ model: 'gpt-4.1', onPermissionRequest: approveAll });
 


### PR DESCRIPTION
The actual Azure SWA handler (`api/src/app.js`) was creating `new CopilotClient()` with no token — falling back to server-side `gh` CLI auth that doesn't exist on Azure. Now passes the user's OAuth token via `{ githubToken: session.githubToken }`.

One-line change. Root `server.js` was already fixed but that's only used for local dev.