### PR TITLE
fix: patch vscode-jsonrpc in api/ for Azure SWA

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -6,6 +6,9 @@
   "engines": {
     "node": ">=20"
   },
+  "scripts": {
+    "postinstall": "node ../scripts/patch-vscode-jsonrpc.js"
+  },
   "dependencies": {
     "@azure/cosmos": "^4.3.1",
     "@azure/functions": "^4.7.0",

--- a/scripts/patch-vscode-jsonrpc.js
+++ b/scripts/patch-vscode-jsonrpc.js
@@ -21,10 +21,12 @@ function patchPackage(pkgDir) {
   return true;
 }
 
-// Patch wherever vscode-jsonrpc lives (could be hoisted or nested under copilot-sdk)
+// Patch wherever vscode-jsonrpc lives (root, nested under copilot-sdk, or in api/)
 const candidates = [
   path.resolve(__dirname, '..', 'node_modules', 'vscode-jsonrpc'),
   path.resolve(__dirname, '..', 'node_modules', '@github', 'copilot-sdk', 'node_modules', 'vscode-jsonrpc'),
+  path.resolve(__dirname, '..', 'api', 'node_modules', 'vscode-jsonrpc'),
+  path.resolve(__dirname, '..', 'api', 'node_modules', '@github', 'copilot-sdk', 'node_modules', 'vscode-jsonrpc'),
 ];
 
 for (const dir of candidates) {


### PR DESCRIPTION
The `postinstall` patch only ran on root `node_modules`. Azure SWA installs `api/` dependencies separately for the Functions runtime, so the ESM exports fix for `vscode-jsonrpc` never applied — causing `CopilotClient` to fail silently and fall back to the basic summary.

Changes:
- Added `api/node_modules` paths to the patch script
- Added `postinstall` hook to `api/package.json`

Tested locally: SDK + `githubToken` works after patching ✅