### PR TITLE
fix: skip Oryx API build to preserve vscode-jsonrpc patch

### DIFF
--- a/.github/workflows/azure-swa.yml
+++ b/.github/workflows/azure-swa.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install API dependencies
         run: cd api && npm ci
 
+      - name: Patch vscode-jsonrpc for ESM compatibility
+        run: node scripts/patch-vscode-jsonrpc.js && node api/patch-vscode-jsonrpc.js
+
       - name: Deploy to Azure Static Web Apps
         # Dependabot PRs do not get this secret. Only deploy on push to main.
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -46,6 +49,7 @@ jobs:
           api_location: "api"
           output_location: ""
           skip_app_build: true
+          skip_api_build: true
 
   close_pull_request:
     # Optional: don't try to close SWA preview environments for Dependabot PRs

--- a/api/package.json
+++ b/api/package.json
@@ -6,9 +6,6 @@
   "engines": {
     "node": ">=20"
   },
-  "scripts": {
-    "postinstall": "node patch-vscode-jsonrpc.js"
-  },
   "dependencies": {
     "@azure/cosmos": "^4.3.1",
     "@azure/functions": "^4.7.0",


### PR DESCRIPTION
Oryx's deploy step runs its own `npm install` in a separate directory (`.oryx_prod_node_modules/`) where our patch script doesn't exist. This is the THIRD deploy failure from the same root cause.

Fix:
- `skip_api_build: true` — Oryx uploads our pre-built `api/` as-is
- Explicit patch step in CI after `npm ci`
- Removed `postinstall` from `api/package.json` (no longer needed)