### PR TITLE
fix: use api_build_command for vscode-jsonrpc patch

### DIFF
--- a/.github/workflows/azure-swa.yml
+++ b/.github/workflows/azure-swa.yml
@@ -34,9 +34,6 @@ jobs:
       - name: Install API dependencies
         run: cd api && npm ci
 
-      - name: Patch vscode-jsonrpc for ESM compatibility
-        run: node scripts/patch-vscode-jsonrpc.js && node api/patch-vscode-jsonrpc.js
-
       - name: Deploy to Azure Static Web Apps
         # Dependabot PRs do not get this secret. Only deploy on push to main.
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -49,7 +46,7 @@ jobs:
           api_location: "api"
           output_location: ""
           skip_app_build: true
-          skip_api_build: true
+          api_build_command: "node patch-vscode-jsonrpc.js || true"
 
   close_pull_request:
     # Optional: don't try to close SWA preview environments for Dependabot PRs


### PR DESCRIPTION
Previous fix (`skip_api_build: true`) broke deploy — Oryx needs to run its API build to detect the function language (Node).

Fix: `api_build_command` overrides just the build step while letting Oryx handle install + language detection. The patch script runs during Oryx's build phase where `node_modules` are already in place.